### PR TITLE
feat(razorpay): list the refunds on a payment

### DIFF
--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -507,6 +507,11 @@ class RazorpaySettings(Document):
 		with razorpay_api_call("refund fetch"):
 			return self.get_client().refund.fetch(refund_id)
 
+	def fetch_refunds(self, payment_id: str) -> list[dict]:
+		"""Every refund Razorpay holds against a payment. Amounts are in paise."""
+		with razorpay_api_call("refund list"):
+			return self.get_client().payment.fetch_multiple_refund(payment_id).get("items", [])
+
 	def refund_payment(self, payment_id: str, amount: float | None = None) -> dict:
 		"""`amount` is in major units; None refunds whatever is still refundable.
 

--- a/payments/payment_gateways/doctype/razorpay_settings/test_razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/test_razorpay_settings.py
@@ -51,6 +51,27 @@ class TestRazorpayFetch(IntegrationTestCase):
 		client.refund.fetch.assert_called_once_with("rfnd_123")
 		self.assertEqual(refund["status"], "processed")
 
+	def test_fetch_refunds_returns_the_refunds_on_a_payment(self):
+		client = MagicMock()
+		client.payment.fetch_multiple_refund.return_value = {
+			"entity": "collection",
+			"count": 1,
+			"items": [{"id": "rfnd_123", "status": "processed", "amount": 5000}],
+		}
+
+		with patch.object(RazorpaySettings, "get_client", return_value=client):
+			refunds = self.settings.fetch_refunds("pay_123")
+
+		client.payment.fetch_multiple_refund.assert_called_once_with("pay_123")
+		self.assertEqual([refund["id"] for refund in refunds], ["rfnd_123"])
+
+	def test_fetch_refunds_is_empty_when_the_payment_has_none(self):
+		client = MagicMock()
+		client.payment.fetch_multiple_refund.return_value = {"entity": "collection", "count": 0, "items": []}
+
+		with patch.object(RazorpaySettings, "get_client", return_value=client):
+			self.assertEqual(self.settings.fetch_refunds("pay_123"), [])
+
 
 CAPTURED_PAYMENT = {
 	"id": "pay_123",


### PR DESCRIPTION
`fetch_payment` reports `amount_refunded` but no refund ids, and `fetch_refund` needs an id you already have — so there is no way to ask Razorpay what refunds exist against a payment. Anything reconciling refunds it did not raise (raised on the dashboard, or a webhook that never arrived) needs exactly that.

### Changed

- `RazorpaySettings.fetch_refunds(payment_id)` — wraps the SDK's `payment.fetch_multiple_refund` (`GET /v1/payments/{id}/refunds`) and returns its `items`. Errors go through the existing `razorpay_api_call` translator; amounts stay in paise like the rest of the gateway.
- Two tests alongside the existing `fetch_payment` / `fetch_refund` delegation tests: the refunds come back, and a payment with none returns `[]`.

Returns Razorpay's default page. No pagination — a payment with more refunds than that page holds is not a case worth carrying code for until someone hits it.

Not changed: no new whitelisted endpoint, no state stored in this app. Consumers call it as a doc method behind their own permission check, the same way `refund_payment` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)